### PR TITLE
Fixed the formatting of line #878 and #889.

### DIFF
--- a/en.sc/out.py/T4222.txt
+++ b/en.sc/out.py/T4222.txt
@@ -875,10 +875,10 @@ this time.[x02]
 ChrTalk #80
 0x101
 
-#1025F#3PI should probably ask Agate and[x02][x03]
+#1025F#3PI should probably ask Agate and Tita before[x02][x01]
+committing to anything. [x02][x03]
 
-
-Tita before committing to anything. We've got Renne, too.[x02]
+We've got Renne, too.[x02]
 
 ;----------------------------------------------------------------------------------
 ;----------------------------------------------------------------------------------
@@ -886,10 +886,10 @@ Tita before committing to anything. We've got Renne, too.[x02]
 ChrTalk #81
 0x101
 
-#1025F#3PI should probably ask Schera and[x02][x03]
+#1025F#3PI should probably ask Schera and Tita before[x02][x01]
+committing to anything. [x02][x03]
 
-
-Tita before committing to anything. We've got Renne, too.[x02]
+We've got Renne, too.[x02]
 
 ;----------------------------------------------------------------------------------
 ;----------------------------------------------------------------------------------

--- a/en.sc/out.py/T4222.txt
+++ b/en.sc/out.py/T4222.txt
@@ -875,7 +875,7 @@ this time.[x02]
 ChrTalk #80
 0x101
 
-#1025F#3PI should probably ask Agate and Tita before[x02][x01]
+#1025F#3PI should probably ask Agate and Tita before[x01]
 committing to anything. [x02][x03]
 
 We've got Renne, too.[x02]
@@ -886,7 +886,7 @@ We've got Renne, too.[x02]
 ChrTalk #81
 0x101
 
-#1025F#3PI should probably ask Schera and Tita before[x02][x01]
+#1025F#3PI should probably ask Schera and Tita before[x01]
 committing to anything. [x02][x03]
 
 We've got Renne, too.[x02]


### PR DESCRIPTION
In game, after it says "Agate" or "Schera", it stops, clear, and write the rest in a new line, as if it was a new sentence. The new formatting is identical to the Evolution, and much better looking. Alignment fits the Evolution side too.